### PR TITLE
Convert core to new format and fix vlog_tb_utils dependency

### DIFF
--- a/wb_bfm-1.0.core
+++ b/wb_bfm-1.0.core
@@ -1,21 +1,42 @@
 CAPI=1
 [main]
 description = Wishbone BFM
-depend = vlog_tb_utils-1.0 wb_common
+depend = wb_common
 simulators = icarus modelsim
 
-[verilog]
-tb_src_files =
+[fileset rtl_files]
+files =
  wb_bfm_master.v
  wb_bfm_slave.v
  wb_bfm_memory.v
  wb_bfm_transactor.v
-tb_private_src_files =
+file_type = verilogSource
+usage = sim synth
+
+[fileset tb]
+files =
  bench/wb_bfm_tb.v
+file_type = verilogSource
+scope = private
+usage = sim
+
+[parameter transactions]
+datatype    = int
+description = Number of test bench transactions
+paramtype   = plusarg
+scope       = private
+
+[parameter subtransactions]
+datatype    = int
+description = Number of test subtransactions to run
+paramtype   = plusarg
+scope       = private
 
 [simulator]
-toplevel=wb_bfm_tb
+toplevel = wb_bfm_tb
 
-[plusargs]
-transactions = int Number of transactions to run
-subtransactions = int Number of subtransactions to run
+[icarus]
+depend = vlog_tb_utils-1.0
+
+[modelsim]
+depend = vlog_tb_utils-1.0


### PR DESCRIPTION
No really functional changes other than moving the vlog_tb_utils to
the simulator dependencies as requested by @olofk after last pull request. 
